### PR TITLE
fix: correct shimataro/ssh-key-action SHA for v2.7.0

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -136,7 +136,7 @@ runs:
 
     - name: Setup SSH for Gerrit
       # yamllint disable-line rule:line-length
-      uses: shimataro/ssh-key-action@dd5cf4e76bb2cdbab9056da8a56bb64e29d1cbb8 # v2.7.0
+      uses: shimataro/ssh-key-action@d4fffb50872869abe2d9a9098a6d9c5aa7d16be4 # v2.7.0
       with:
         key: ${{ inputs.ssh_private_key }}
         name: id_rsa


### PR DESCRIPTION
The previous SHA dd5cf4e76bb2cdbab9056da8a56bb64e29d1cbb8 was invalid and causing GitHub Actions to fail when downloading the action. Updated to the correct SHA d4fffb50872869abe2d9a9098a6d9c5aa7d16be4 for v2.7.0.