### PR TITLE
Fix: Support single-segment Gerrit project paths

### DIFF
--- a/.github/scripts/extract_ssh_inputs.sh
+++ b/.github/scripts/extract_ssh_inputs.sh
@@ -36,7 +36,7 @@ extract_hostname() {
 
 # Extract project from URL
 extract_project() {
-  echo "$1" | sed -E 's#.*/c/([^/]+/[^/]+)/\+.*#\1#'
+  echo "$1" | sed -E 's#.*/c/([^+]+)/\+.*#\1#'
 }
 
 # Extract change number

--- a/.github/scripts/gerrit_query.sh
+++ b/.github/scripts/gerrit_query.sh
@@ -40,7 +40,7 @@ if [[ -n "$cid_patch_set_no" && ! "$cid_patch_set_no" =~ ^[0-9]+$ ]]; then
 fi
 
 extract_project() {
-  echo "$1" | sed -E 's#.*/c/([^/]+/[^/]+)/\+.*#\1#'
+  echo "$1" | sed -E 's#.*/c/([^+]+)/\+.*#\1#'
 }
 
 extract_change_number() {

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -44,26 +44,45 @@ jobs:
         run: |
           echo "Testing extract_ssh_inputs.sh with various URLs..."
 
-          # Test valid URL
+          # Test single-segment project path
           .github/scripts/extract_ssh_inputs.sh \
-            "https://git.opendaylight.org/gerrit/c/releng/builder/+/111445"
+            "https://git.opendaylight.org/gerrit/c/docs/+/118037"
           if [[ -f gerrit_ssh_info.env ]]; then
-            echo "✓ Valid URL test passed"
+            echo "✓ Single-segment path test passed"
             cat gerrit_ssh_info.env
+            # Verify correct project extraction
+            if grep -q "GERRIT_PROJECT=docs" gerrit_ssh_info.env; then
+              echo "  ✓ Project correctly extracted as 'docs'"
+            else
+              echo "  ✗ Project extraction failed"
+              exit 1
+            fi
             rm gerrit_ssh_info.env
           else
-            echo "✗ Valid URL test failed"
+            echo "✗ Single-segment path test failed"
             exit 1
           fi
 
-          # Test URL with patchset
+          # Test two-segment project path
+          .github/scripts/extract_ssh_inputs.sh \
+            "https://git.opendaylight.org/gerrit/c/releng/builder/+/111445"
+          if [[ -f gerrit_ssh_info.env ]]; then
+            echo "✓ Two-segment path test passed"
+            cat gerrit_ssh_info.env
+            rm gerrit_ssh_info.env
+          else
+            echo "✗ Two-segment path test failed"
+            exit 1
+          fi
+
+          # Test three-segment project path with patchset
           .github/scripts/extract_ssh_inputs.sh \
             "https://gerrit.example.org/c/project/subproject/+/12345/6"
           if [[ -f gerrit_ssh_info.env ]]; then
-            echo "✓ URL with patchset test passed"
+            echo "✓ Three-segment path with patchset test passed"
             rm gerrit_ssh_info.env
           else
-            echo "✗ URL with patchset test failed"
+            echo "✗ Three-segment path with patchset test failed"
             exit 1
           fi
 


### PR DESCRIPTION
The URL extraction regex required at least two path segments (e.g., org/project), which failed for single-segment paths like 'docs' in URLs such as:
https://git.opendaylight.org/gerrit/c/docs/+/118037

Changed regex from [^/]+/[^/]+ to [^+]+ to match one or more path segments between /c/ and /+/ in the URL structure.

Updated files:
- .github/scripts/extract_ssh_inputs.sh
- .github/scripts/gerrit_query.sh
- .github/workflows/testing.yaml (added test coverage)

Fixes support for OpenDaylight 'docs' project and any other single-segment Gerrit project paths.