### PR TITLE
Fix: harden action against shell/env injection

### DIFF
--- a/.github/scripts/extract_ssh_inputs.sh
+++ b/.github/scripts/extract_ssh_inputs.sh
@@ -61,6 +61,19 @@ if ! [[ "$change_number" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
+# Validate hostname and project against safe character sets. These values
+# flow into the runner environment (and the downstream SSH config), so
+# reject anything that could enable injection.
+if [[ ! "$gerrit_hostname" =~ ^[A-Za-z0-9.-]+$ ]]; then
+  echo "Error: Invalid Gerrit hostname: '$gerrit_hostname'" >&2
+  exit 1
+fi
+
+if [[ ! "$project" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+  echo "Error: Invalid Gerrit project: '$project'" >&2
+  exit 1
+fi
+
 {
   echo "GERRIT_HOSTNAME=$gerrit_hostname"
   echo "GERRIT_PROJECT=$project"

--- a/.github/scripts/gerrit_query.sh
+++ b/.github/scripts/gerrit_query.sh
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
-# Usage: ./gerrit_query.sh <gerrit_url> <patchset_number> <ssh_user_name>
+# Usage: ./gerrit_query.sh <gerrit_url> <patchset_number> <ssh_user_name> \
+#          [gerrit_server_port]
 
 set -euo pipefail
 
@@ -14,13 +15,16 @@ WORK_DIR="$(pwd)"
 SSH_TIMEOUT=30
 
 if [ "$#" -lt 3 ]; then
-  echo "Error: Usage: $0 <gerrit_url> <patchset_number> <ssh_user_name>" >&2
+  echo "Error: Usage: $0 <gerrit_url> <patchset_number> <ssh_user_name>" \
+    "[gerrit_server_port]" >&2
   exit 1
 fi
 
 gerrit_url="$1"
 cid_patch_set_no="$2"
 ssh_user_name="$3"
+# Gerrit SSH port; defaults to the standard Gerrit port when omitted.
+gerrit_server_port="${4:-29418}"
 
 # Validate inputs
 if [[ -z "$gerrit_url" ]]; then
@@ -36,6 +40,29 @@ fi
 # Validate patchset number if provided
 if [[ -n "$cid_patch_set_no" && ! "$cid_patch_set_no" =~ ^[0-9]+$ ]]; then
   echo "Error: Patchset number must be numeric, got: '$cid_patch_set_no'" >&2
+  exit 1
+fi
+
+# Validate Gerrit URL format
+if [[ ! "$gerrit_url" =~ ^https?://[^/]+/.*c/.*/\+/[0-9]+ ]]; then
+  echo "Error: Invalid Gerrit URL format." \
+    "Expected: https://hostname/gerrit/c/project/+/number" >&2
+  exit 1
+fi
+
+# Restrict the SSH username to a safe character set; it is used verbatim
+# in the SSH connection target. A leading dash is rejected so the value
+# cannot be parsed as an SSH option (option-injection).
+if [[ ! "$ssh_user_name" =~ ^[A-Za-z0-9._][A-Za-z0-9._-]*$ ]]; then
+  echo "Error: Invalid SSH username: '$ssh_user_name'" >&2
+  exit 1
+fi
+
+# Validate the Gerrit SSH port as a numeric TCP port (1-65535).
+if [[ ! "$gerrit_server_port" =~ ^[0-9]+$ ]] \
+    || [ "$gerrit_server_port" -lt 1 ] \
+    || [ "$gerrit_server_port" -gt 65535 ]; then
+  echo "Error: Invalid Gerrit server port: '$gerrit_server_port'" >&2
   exit 1
 fi
 
@@ -55,23 +82,50 @@ gerrit_hostname=$(extract_hostname "$gerrit_url")
 change_number=$(extract_change_number "$gerrit_url")
 project=$(extract_project "$gerrit_url")
 
-# Build SSH command with timeout and better error handling
-ssh_command="timeout $SSH_TIMEOUT ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=yes -p 29418 $ssh_user_name@$gerrit_hostname 'gerrit query --format=JSON project:$project change:$change_number is:open limit:1"
-
-if [ -n "$cid_patch_set_no" ]; then
-    ssh_command="$ssh_command --patch-sets"
-else
-    ssh_command="$ssh_command --current-patch-set"
+# Validate extracted values against safe character sets before they are
+# used to build the (remote) Gerrit query command. This prevents command
+# or query injection via a crafted Gerrit change URL.
+if [[ ! "$change_number" =~ ^[0-9]+$ ]]; then
+  echo "Error: Change number must be numeric, got: '$change_number'" >&2
+  exit 1
 fi
 
-ssh_command="$ssh_command'"
+if [[ ! "$gerrit_hostname" =~ ^[A-Za-z0-9.-]+$ ]]; then
+  echo "Error: Invalid Gerrit hostname: '$gerrit_hostname'" >&2
+  exit 1
+fi
+
+if [[ ! "$project" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+  echo "Error: Invalid Gerrit project: '$project'" >&2
+  exit 1
+fi
+
+# Build the remote Gerrit query command. All interpolated values are
+# validated above, and the command is passed to ssh as a single argument
+# via an argument array (no local 'eval'), eliminating shell injection on
+# the runner.
+remote_query="gerrit query --format=JSON project:$project change:$change_number is:open limit:1"
+
+if [ -n "$cid_patch_set_no" ]; then
+    remote_query="$remote_query --patch-sets"
+else
+    remote_query="$remote_query --current-patch-set"
+fi
+
+ssh_args=(
+    -o ConnectTimeout=10
+    -o StrictHostKeyChecking=yes
+    -p "$gerrit_server_port"
+    --
+    "${ssh_user_name}@${gerrit_hostname}"
+    "$remote_query"
+)
 
 echo "Executing Gerrit query for change $change_number in project $project..." >&2
 
 # Execute SSH command with proper error handling
-if ! json_output=$(eval "$ssh_command" 2>&1); then
+if ! json_output=$(timeout "$SSH_TIMEOUT" ssh "${ssh_args[@]}" 2>&1); then
   echo "Error: SSH connection to Gerrit failed" >&2
-  echo "Command: $ssh_command" >&2
   echo "Output: $json_output" >&2
   exit 1
 fi

--- a/action.yaml
+++ b/action.yaml
@@ -72,32 +72,37 @@ runs:
   steps:
     - name: Checkout repository
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        # This action only reads the repo and queries Gerrit; it never
+        # pushes, so the checkout token must not be persisted to
+        # .git/config (artipacked hardening).
+        persist-credentials: false
 
     - name: Setup working directory and validate path_prefix
       # yamllint disable rule:line-length
       shell: bash
+      env:
+        PATH_PREFIX: ${{ inputs.path_prefix }}
       run: |
-        path_prefix="${{ inputs.path_prefix }}"
-
         # Validate path_prefix is not empty
-        if [[ -z "$path_prefix" ]]; then
+        if [[ -z "$PATH_PREFIX" ]]; then
           echo "Error: path_prefix cannot be empty" >&2
           exit 1
         fi
 
         # Check for dangerous characters or paths
-        if [[ "$path_prefix" =~ \.\./|^\.\.$|/\.\./|/\.\.$|^\.\.|^/ ]]; then
+        if [[ "$PATH_PREFIX" =~ \.\./|^\.\.$|/\.\./|/\.\.$|^\.\.|^/ ]]; then
           echo "Error: path_prefix cannot contain '..' (parent directory references) or start with '/' (absolute paths)" >&2
           exit 1
         fi
 
         # Create the directory if it doesn't exist and it's not the default
-        if [[ "$path_prefix" != "." && ! -d "$path_prefix" ]]; then
-          echo "Creating directory: $path_prefix" >&2
-          mkdir -p "$path_prefix"
+        if [[ "$PATH_PREFIX" != "." && ! -d "$PATH_PREFIX" ]]; then
+          echo "Creating directory: $PATH_PREFIX" >&2
+          mkdir -p "$PATH_PREFIX"
         fi
 
-        echo "Path prefix validation and setup completed: $path_prefix" >&2
+        echo "Path prefix validation and setup completed: $PATH_PREFIX" >&2
 
     - name: Install jq
       shell: bash
@@ -105,25 +110,49 @@ runs:
 
     - name: Validate inputs
       shell: bash
+      env:
+        GERRIT_CHANGE_URL: ${{ inputs.gerrit_change_url }}
+        SSH_USER_NAME: ${{ inputs.ssh_user_name }}
+        SSH_PRIVATE_KEY: ${{ inputs.ssh_private_key }}
+        GERRIT_KNOWN_HOSTS: ${{ inputs.gerrit_known_hosts }}
+        GERRIT_SERVER_PORT: ${{ inputs.gerrit_server_port }}
       run: |
         # Validate required inputs
-        if [[ -z "${{ inputs.gerrit_change_url }}" ]]; then
+        if [[ -z "$GERRIT_CHANGE_URL" ]]; then
           echo "Error: gerrit_change_url is required" >&2
           exit 1
         fi
 
-        if [[ -z "${{ inputs.ssh_user_name }}" ]]; then
+        if [[ -z "$SSH_USER_NAME" ]]; then
           echo "Error: ssh_user_name is required" >&2
           exit 1
         fi
 
-        if [[ -z "${{ inputs.ssh_private_key }}" ]]; then
+        if [[ -z "$SSH_PRIVATE_KEY" ]]; then
           echo "Error: ssh_private_key is required" >&2
           exit 1
         fi
 
-        if [[ -z "${{ inputs.gerrit_known_hosts }}" ]]; then
+        if [[ -z "$GERRIT_KNOWN_HOSTS" ]]; then
           echo "Error: gerrit_known_hosts is required" >&2
+          exit 1
+        fi
+
+        # Restrict ssh_user_name to a safe character set; it is
+        # interpolated into the generated SSH config and used to build the
+        # SSH destination. A leading dash is rejected so the value cannot
+        # be parsed as an SSH option (option-injection).
+        if [[ ! "$SSH_USER_NAME" =~ ^[A-Za-z0-9._][A-Za-z0-9._-]*$ ]]; then
+          echo "Error: Invalid ssh_user_name: '$SSH_USER_NAME'" >&2
+          exit 1
+        fi
+
+        # Validate gerrit_server_port as a numeric TCP port (1-65535); it
+        # is interpolated into the generated SSH config.
+        if [[ ! "$GERRIT_SERVER_PORT" =~ ^[0-9]+$ ]] \
+            || [ "$GERRIT_SERVER_PORT" -lt 1 ] \
+            || [ "$GERRIT_SERVER_PORT" -gt 65535 ]; then
+          echo "Error: Invalid gerrit_server_port: '$GERRIT_SERVER_PORT'" >&2
           exit 1
         fi
 
@@ -131,13 +160,15 @@ runs:
 
     - name: Validate SSH key format
       shell: bash
+      env:
+        SSH_PRIVATE_KEY: ${{ inputs.ssh_private_key }}
       run: |
         # Create temporary file for secure SSH key validation
         temp_key_file=$(mktemp)
         trap 'rm -f "$temp_key_file"' EXIT
 
         # Write key to temporary file for validation
-        echo "${{ inputs.ssh_private_key }}" > "$temp_key_file"
+        printf '%s\n' "$SSH_PRIVATE_KEY" > "$temp_key_file"
 
         # Basic SSH private key validation using file operations
         if ! head -n 1 "$temp_key_file" | grep -q "BEGIN.*PRIVATE KEY"; then
@@ -157,23 +188,36 @@ runs:
       # yamllint disable rule:line-length
       id: ssh
       shell: bash
-      run: |
-        path_prefix="${{ inputs.path_prefix }}"
-
+      env:
+        PATH_PREFIX: ${{ inputs.path_prefix }}
+        ACTION_PATH: ${{ github.action_path }}
+        GERRIT_CHANGE_URL: ${{ inputs.gerrit_change_url }}
+      # The GITHUB_ENV writes below are intentional: GERRIT_HOSTNAME is
+      # consumed by the next step's SSH config, and the action exports
+      # Gerrit values to the job environment. Only an explicit allow-list
+      # of keys is written and the helper script validates the values,
+      # so arbitrary-variable injection is prevented.
+      run: | # zizmor: ignore[github-env]
         # Change to the specified directory
-        if [[ "$path_prefix" != "." ]]; then
-          cd "$path_prefix"
+        if [[ "$PATH_PREFIX" != "." ]]; then
+          cd "$PATH_PREFIX"
           echo "Changed to directory: $(pwd)" >&2
         fi
 
-        chmod +x "${{ github.action_path }}/.github/scripts/extract_ssh_inputs.sh"
-        "${{ github.action_path }}/.github/scripts/extract_ssh_inputs.sh" \
-          "${{ inputs.gerrit_change_url }}"
+        chmod +x "${ACTION_PATH}/.github/scripts/extract_ssh_inputs.sh"
+        "${ACTION_PATH}/.github/scripts/extract_ssh_inputs.sh" \
+          "$GERRIT_CHANGE_URL"
 
-        source gerrit_ssh_info.env
-        echo "GERRIT_HOSTNAME=$GERRIT_HOSTNAME" >> $GITHUB_ENV
-        echo "GERRIT_PROJECT=$GERRIT_PROJECT" >> $GITHUB_ENV
-        echo "GERRIT_CHANGE_NUMBER=$GERRIT_CHANGE_NUMBER" >> $GITHUB_ENV
+        # Safely import extracted values. The file is parsed as KEY=VALUE
+        # data against an explicit allow-list; it is NOT sourced, so a
+        # crafted value cannot execute code on the runner.
+        while IFS='=' read -r key value; do
+          case "$key" in
+            GERRIT_HOSTNAME|GERRIT_PROJECT|GERRIT_CHANGE_NUMBER)
+              printf '%s=%s\n' "$key" "$value" >> "$GITHUB_ENV"
+              ;;
+          esac
+        done < gerrit_ssh_info.env
 
     - name: Setup SSH for Gerrit
       # yamllint disable rule:line-length
@@ -197,25 +241,44 @@ runs:
       id: gerrit
       shell: bash
       # yamllint disable rule:line-length
-      run: |
-        path_prefix="${{ inputs.path_prefix }}"
-
+      env:
+        PATH_PREFIX: ${{ inputs.path_prefix }}
+        ACTION_PATH: ${{ github.action_path }}
+        GERRIT_CHANGE_URL: ${{ inputs.gerrit_change_url }}
+        GERRIT_PATCHSET_NUMBER: ${{ inputs.gerrit_patchset_number }}
+        SSH_USER_NAME: ${{ inputs.ssh_user_name }}
+        GERRIT_SERVER_PORT: ${{ inputs.gerrit_server_port }}
+      # The GITHUB_ENV/GITHUB_OUTPUT writes below export Gerrit query
+      # results to the job environment for downstream steps and consumers.
+      # Only an explicit allow-list of Gerrit keys is written (see the
+      # 'allowed' regex) and the helper script validates the values, so
+      # arbitrary-variable injection is prevented.
+      run: | # zizmor: ignore[github-env]
         # Change to the specified directory
-        if [[ "$path_prefix" != "." ]]; then
-          cd "$path_prefix"
+        if [[ "$PATH_PREFIX" != "." ]]; then
+          cd "$PATH_PREFIX"
           echo "Changed to directory: $(pwd)" >&2
         fi
 
-        chmod +x "${{ github.action_path }}/.github/scripts/gerrit_query.sh"
-        "${{ github.action_path }}/.github/scripts/gerrit_query.sh" \
-            "${{ inputs.gerrit_change_url }}" \
-            "${{ inputs.gerrit_patchset_number }}" \
-            "${{ inputs.ssh_user_name }}"
+        chmod +x "${ACTION_PATH}/.github/scripts/gerrit_query.sh"
+        "${ACTION_PATH}/.github/scripts/gerrit_query.sh" \
+            "$GERRIT_CHANGE_URL" \
+            "$GERRIT_PATCHSET_NUMBER" \
+            "$SSH_USER_NAME" \
+            "$GERRIT_SERVER_PORT"
 
+        # Export query results to the environment and step outputs. Only an
+        # explicit allow-list of Gerrit keys is written, guarding against
+        # injection of arbitrary variables via a crafted Gerrit field.
+        allowed='^(GERRIT_BRANCH|GERRIT_CHANGE_ID|GERRIT_CHANGE_URL|GERRIT_CHANGE_NUMBER|GERRIT_EVENT_TYPE|GERRIT_PATCHSET_NUMBER|GERRIT_PATCHSET_REVISION|GERRIT_PROJECT|GERRIT_REFSPEC|GERRIT_HOSTNAME)='
         if [ -s "${GERRIT_CHANGE_NUMBER}.file" ]; then
           while IFS= read -r envvar; do
-            echo "$envvar" >> $GITHUB_ENV
-            echo "$envvar" >> $GITHUB_OUTPUT
+            if [[ "$envvar" =~ $allowed ]]; then
+              printf '%s\n' "$envvar" >> "$GITHUB_ENV"
+              printf '%s\n' "$envvar" >> "$GITHUB_OUTPUT"
+            else
+              echo "Skipping unexpected output line: $envvar" >&2
+            fi
           done < "${GERRIT_CHANGE_NUMBER}.file"
         else
           echo "Error: Gerrit query output file not found or empty."
@@ -224,50 +287,27 @@ runs:
 
     - name: Validate file output
       shell: bash
+      env:
+        PATH_PREFIX: ${{ inputs.path_prefix }}
+        GERRIT_CHANGE_NUMBER: ${{ steps.gerrit.outputs.GERRIT_CHANGE_NUMBER }}
       run: |
-        path_prefix="${{ inputs.path_prefix }}"
-
         # Change to the specified directory
-        if [[ "$path_prefix" != "." ]]; then
-          cd "$path_prefix"
+        if [[ "$PATH_PREFIX" != "." ]]; then
+          cd "$PATH_PREFIX"
           echo "Validating file output in directory: $(pwd)" >&2
         fi
 
-        change_number="${{ steps.gerrit.outputs.GERRIT_CHANGE_NUMBER }}"
-        if [ ! -f "$change_number".file ]; then
-          echo "Missing file output: $change_number.file"
+        if [ ! -f "${GERRIT_CHANGE_NUMBER}.file" ]; then
+          echo "Missing file output: ${GERRIT_CHANGE_NUMBER}.file"
           exit 1
         fi
 
     - name: Verify change-id
       shell: bash
+      env:
+        GERRIT_CHANGE_ID: ${{ steps.gerrit.outputs.GERRIT_CHANGE_ID }}
       run: |
-        if [[ -z "${{ steps.gerrit.outputs.GERRIT_CHANGE_ID }}" ]]; then
+        if [[ -z "$GERRIT_CHANGE_ID" ]]; then
           echo "Error: Gerrit query failed or change not found."
           exit 1
         fi
-
-    - name: Export Gerrit outputs
-      shell: bash
-      run: |
-        echo "GERRIT_BRANCH=${{ steps.gerrit.outputs.GERRIT_BRANCH }}" \
-          >> "$GITHUB_ENV"
-        echo "GERRIT_CHANGE_ID=${{ steps.gerrit.outputs.GERRIT_CHANGE_ID }}" \
-          >> "$GITHUB_ENV"
-        echo "GERRIT_CHANGE_URL=${{ steps.gerrit.outputs.GERRIT_CHANGE_URL }}" \
-          >> "$GITHUB_ENV"
-        echo "GERRIT_CHANGE_NUMBER=" \
-          "${{ steps.gerrit.outputs.GERRIT_CHANGE_NUMBER }}" >> "$GITHUB_ENV"
-        echo "GERRIT_EVENT_TYPE=${{ steps.gerrit.outputs.GERRIT_EVENT_TYPE }}" \
-          >> "$GITHUB_ENV"
-        echo "GERRIT_PATCHSET_NUMBER=" \
-          "${{ steps.gerrit.outputs.GERRIT_PATCHSET_NUMBER }}" >> "$GITHUB_ENV"
-        echo "GERRIT_PATCHSET_REVISION=" \
-          "${{ steps.gerrit.outputs.GERRIT_PATCHSET_REVISION }}" \
-          >> "$GITHUB_ENV"
-        echo "GERRIT_PROJECT=${{ steps.gerrit.outputs.GERRIT_PROJECT }}" \
-          >> "$GITHUB_ENV"
-        echo "GERRIT_REFSPEC=${{ steps.gerrit.outputs.GERRIT_REFSPEC }}" \
-          >> "$GITHUB_ENV"
-        echo "GERRIT_HOSTNAME=${{ steps.gerrit.outputs.GERRIT_HOSTNAME }}" \
-          >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

A holistic security-hardening pass over the composite action and its
helper scripts. It was prompted by a zizmor scan (23 high findings:
`template-injection` and `github-env`), but intentionally goes beyond
those findings to address **every dangerous data flow** discovered
while reviewing the action — including two command-injection vectors
that zizmor cannot see because they live in the shell scripts.

**No changes to the action's `inputs` or `outputs` — consumers are unaffected.**

## Dangerous data flows fixed

### Command injection (not visible to zizmor)
- **`eval` of an interpolated SSH command** in `gerrit_query.sh`: the
  remote query was assembled by string interpolation of URL-derived
  `project` / `hostname` / `change_number` and run via `eval`. Replaced
  with an `ssh` argument array (no `eval`), and the values are now
  validated against safe character sets before use.
- **`source gerrit_ssh_info.env`** in `action.yaml`: the sourced file is
  built from URL parsing, so a crafted value (e.g. `proj$(cmd)`) would
  execute on the runner. Replaced with an allow-listed `KEY=VALUE` parse
  that never executes file contents.

### Template injection (`template-injection`, High)
- Every `${{ ... }}` expression used inside a `run:` body (across 7
  steps) is moved into an `env:` block and referenced as a quoted shell
  variable, so untrusted values reach the shell as **data**, never as
  script text.

### Environment-file writes (`github-env`, High)
- `GITHUB_ENV` / `GITHUB_OUTPUT` writes are restricted to an explicit
  **allow-list** of `GERRIT_*` keys, preventing injection of arbitrary
  variables (e.g. `LD_PRELOAD`) via newline-bearing fields.
- The remaining writes are intrinsic to the action's purpose (it exports
  Gerrit values to the job environment; `GERRIT_HOSTNAME` is consumed by
  the SSH-config step). These carry **scoped, documented**
  `# zizmor: ignore[github-env]` suppressions rather than a blanket ignore.

### Other hardening / cleanup
- `persist-credentials: false` on `actions/checkout` — the action never
  pushes, so the token must not be persisted to `.git/config`
  (`artipacked`).
- Added project/hostname validation to `extract_ssh_inputs.sh`.
- **Deleted the redundant `Export Gerrit outputs` step.** The `Run Gerrit
  Query` step already populates both the environment and step outputs;
  the deleted step also had a latent bug (`echo "K=" "val"` injected a
  stray leading space into `GERRIT_CHANGE_NUMBER`,
  `GERRIT_PATCHSET_NUMBER` and `GERRIT_PATCHSET_REVISION`).

## Validation
- `zizmor --offline action.yaml`: **No findings** (2 scoped, justified ignores).
- `shellcheck`, `bash -n`, `actionlint` (workflows), and the repo's full
  `pre-commit` suite (yamllint, reuse, codespell, GitHub Actions
  validation) all pass.

Co-authored-by: Claude <noreply@anthropic.com>