### PR TITLE
Fix: Bump Scorecard to v0.7.2 and clear zizmor findings

### DIFF
--- a/.github/workflows/clear-action-cache.yaml
+++ b/.github/workflows/clear-action-cache.yaml
@@ -46,8 +46,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      # Actions cache deletion requires the actions: write scope.
-      actions: write
+      # yamllint disable-line rule:line-length
+      actions: write  # Required to list and delete repository Actions caches
     steps:
       # Harden the runner
       # yamllint disable-line rule:line-length
@@ -59,13 +59,15 @@ jobs:
         id: before
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           KEY_PATTERN: ${{ inputs.key_pattern }}
           REF_FILTER: ${{ inputs.ref_filter }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           # List current cache entries (pre-deletion snapshot).
           set -euo pipefail
 
-          echo "Repository: ${{ github.repository }}"
+          echo "Repository: $REPO"
           echo "Key filter: '${KEY_PATTERN:-<none>}'"
           echo "Ref filter: '${REF_FILTER:-<none>}'"
           echo ""
@@ -77,7 +79,7 @@ jobs:
             gh api \
               --paginate \
               -H "Accept: application/vnd.github+json" \
-              "/repos/${{ github.repository }}/actions/caches?per_page=100" \
+              "/repos/$REPO/actions/caches?per_page=100" \
               --jq '.actions_caches[]'
           )
 
@@ -130,7 +132,7 @@ jobs:
             echo "|----------|-------|"
             echo "| Total entries | $before_count |"
             echo "| Matched | $matched_count |"
-            echo "| Dry run | \`${{ inputs.dry_run }}\` |"
+            echo "| Dry run | \`${DRY_RUN}\` |"
             echo ""
             # Render user-controlled filter inputs inside a fenced
             # code block. KEY_PATTERN and REF_FILTER are free-form
@@ -173,6 +175,7 @@ jobs:
         id: delete
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           # Delete the matched cache IDs unless this is a dry run.
@@ -205,7 +208,7 @@ jobs:
             if gh api \
                 --method DELETE \
                 -H "Accept: application/vnd.github+json" \
-                "/repos/${{ github.repository }}/actions/caches/${cache_id}";
+                "/repos/$REPO/actions/caches/${cache_id}";
             then
               deleted=$((deleted + 1))
             else
@@ -238,6 +241,7 @@ jobs:
         if: always() && steps.before.outputs.matched_count != '0'
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           KEY_PATTERN: ${{ inputs.key_pattern }}
           REF_FILTER: ${{ inputs.ref_filter }}
           DRY_RUN: ${{ inputs.dry_run }}
@@ -250,7 +254,7 @@ jobs:
             gh api \
               --paginate \
               -H "Accept: application/vnd.github+json" \
-              "/repos/${{ github.repository }}/actions/caches?per_page=100" \
+              "/repos/$REPO/actions/caches?per_page=100" \
               --jq '.actions_caches[]'
           )
 

--- a/.github/workflows/openssf-scorecard.yaml
+++ b/.github/workflows/openssf-scorecard.yaml
@@ -28,13 +28,11 @@ jobs:
   openssf-scorecard:
     name: "OpenSSF Scorecard"
     # yamllint disable-line rule:line-length
-    uses: lfit/releng-reusable-workflows/.github/workflows/reuse-openssf-scorecard.yaml@50e324ef804880c13d4aebcefcac07ad81661d01  # v0.6.1
+    uses: lfit/releng-reusable-workflows/.github/workflows/reuse-openssf-scorecard.yaml@fd3c1b43bc919e9e70787b009ffa2768ddbb1267  # v0.7.2
     permissions:
-      # Needed to read repository contents (checkout, etc.).
-      contents: read
-      # Needed to upload the results to the code-scanning dashboard.
-      security-events: write
-      # Needed to publish results and obtain a Scorecard badge via OIDC.
-      id-token: write
+      contents: read  # Read repository contents (checkout, etc.)
+      # yamllint disable-line rule:line-length
+      security-events: write  # Upload results to the code-scanning dashboard
+      id-token: write  # Publish results and obtain Scorecard badge via OIDC
       # Uncomment the permission below if installing in a private repository.
       # actions: read

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -20,8 +20,7 @@ jobs:
   update_release_draft:
     name: 'Update Release Draft'
     permissions:
-      # write permission is required to create releases
-      contents: write
+      contents: write  # Create and update draft releases
     runs-on: 'ubuntu-latest'
     timeout-minutes: 3
     steps:

--- a/.github/workflows/tag-push.yaml
+++ b/.github/workflows/tag-push.yaml
@@ -13,6 +13,13 @@ on:
 
 permissions: {}
 
+# Serialise repeated runs for the same tag; never cancel an in-flight
+# release promotion. Distinct tags use distinct groups and proceed
+# independently.
+concurrency:
+  group: '${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: false
+
 jobs:
   validate_tag:
     name: 'Validate Tag'
@@ -53,7 +60,7 @@ jobs:
     needs: validate_tag
     runs-on: 'ubuntu-latest'
     permissions:
-      contents: write
+      contents: write  # Promote (publish) the draft release for the tag
     timeout-minutes: 5
     steps:
       # Harden the runner used by this workflow

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -18,6 +18,10 @@ on:
       - '!.*'
       - '!tox.ini'
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
@@ -143,16 +147,20 @@ jobs:
 
       - name: "Test action dependencies"
         shell: bash
+        env:
+          MATRIX_OS: ${{ matrix.os }}
         run: |
-          echo "Testing on ${{ matrix.os }}..."
+          echo "Testing on ${MATRIX_OS}..."
 
           # Check required tools
           echo "Checking dependencies..."
           which ssh || (echo "SSH not available" && exit 1)
-          which jq || sudo apt-get update && sudo apt-get install -y jq
+          command -v jq >/dev/null || {
+            sudo apt-get update && sudo apt-get install -y jq
+          }
           which timeout || (echo "timeout not available" && exit 1)
 
-          echo "✓ Dependencies check passed on ${{ matrix.os }}"
+          echo "✓ Dependencies check passed on ${MATRIX_OS}"
 
       - name: "Test action input validation"
         uses: ./
@@ -167,6 +175,8 @@ jobs:
   tests:
     name: "Test local GitHub Action"
     runs-on: ubuntu-latest
+    # Dedicated environment scopes access to the Gerrit test secrets
+    environment: 'development'
     permissions:
       contents: read
     timeout-minutes: 5
@@ -201,9 +211,11 @@ jobs:
 
       - name: "Validating local action: ${{ github.repository }}"
         shell: bash
+        env:
+          REPO: ${{ github.repository }}
         run: |
           # Local action validation
-          echo "Validating local action: ${{ github.repository }}"
+          echo "Validating local action: ${REPO}"
           echo "Validation step summary output" >> "$GITHUB_STEP_SUMMARY"
 
       - name: "Test: Missing SSH Key"
@@ -274,6 +286,8 @@ jobs:
   test-default-path:
     name: Test Default Path Prefix
     runs-on: ubuntu-latest
+    # Dedicated environment scopes access to the Gerrit test secrets
+    environment: 'development'
     timeout-minutes: 10
     steps:
       # yamllint disable-line rule:line-length
@@ -313,6 +327,8 @@ jobs:
   test-custom-path:
     name: Test Custom Path Prefix
     runs-on: ubuntu-latest
+    # Dedicated environment scopes access to the Gerrit test secrets
+    environment: 'development'
     timeout-minutes: 10
     steps:
       # yamllint disable-line rule:line-length
@@ -366,6 +382,8 @@ jobs:
   test-error-handling:
     name: Test Error Handling
     runs-on: ubuntu-latest
+    # Dedicated environment scopes access to the Gerrit test secrets
+    environment: 'development'
     timeout-minutes: 10
     continue-on-error: true
     steps:


### PR DESCRIPTION
## Purpose

1. Bump the OpenSSF Scorecard caller from the broken **v0.6.1** reusable
   to **v0.7.2**, which fixes the org-wide Scorecard publish failures
   under harden-runner block mode (and allow-lists `api.deps.dev`).
2. Resolve **all** zizmor findings (up to the `auditor` persona) in the
   workflow files so the scan reports zero results.

## Changes

### OpenSSF Scorecard pin bump

```diff
-uses: …/reuse-openssf-scorecard.yaml@50e324ef…  # v0.6.1
+uses: …/reuse-openssf-scorecard.yaml@fd3c1b43…  # v0.7.2
```

### Zizmor cleanup (zero findings at `--persona=auditor`)

- **undocumented-permissions**: inline trailing permission comments
  (`clear-action-cache`, `openssf-scorecard`, `release-drafter`,
  `tag-push`).
- **template-injection**: move `${{ github.repository }}` /
  `${{ inputs.dry_run }}` into step `env:` vars (`REPO`, `DRY_RUN`) in
  `clear-action-cache`; move `${{ matrix.os }}` and
  `${{ github.repository }}` into `MATRIX_OS` / `REPO` env vars in
  `testing`.
- **concurrency-limits**: add workflow-level `concurrency` blocks to
  `tag-push` and `testing`.
- **secrets-outside-env**: scope the Gerrit test secrets to the existing
  dedicated `development` environment on the `tests`,
  `test-default-path`, `test-custom-path` and `test-error-handling`
  jobs in `testing.yaml`.

Harden-runner **audit** mode and existing action pins (notably
`tag-validate-action` v1.0.4) are intentionally left unchanged.

## Validation

- `zizmor --persona=auditor .github/workflows/` → **No findings to report.**
- `prek run` on changed files → all hooks pass.
